### PR TITLE
improvements based on in depth testing

### DIFF
--- a/crane-export-playbook.yml
+++ b/crane-export-playbook.yml
@@ -28,19 +28,5 @@
   - name: Create transforms
     shell: "{{ crane_path }}/crane transform --from-openshift --export-dir=export/resources"
 
-  - name: Find token transforms
-    find:
-      path: "{{ playbook_dir }}/transform"
-      recurse: true
-      patterns: 'transforms-Secret.*token.*yaml'
-      use_regex: true
-    register: tokens
-
-  - name: Add token label json patch
-    copy:
-      content: '[{"op":"add","path":"/metadata/labels", "value": {}},{"op":"add","path":"/metadata/labels/exported-by", "value":"crane2"}]'
-      dest: "{{ item.path }}"
-    with_items: "{{ tokens.files }}"
-
   - name: Apply Transforms
     shell: "{{ crane_path }}/crane apply --export-dir=export/resources"

--- a/crane-import-delete-kube-root-ca.yml
+++ b/crane-import-delete-kube-root-ca.yml
@@ -1,0 +1,4 @@
+- name: Delete kube-root-ca.crt configmap if it exists
+  file:
+    state: absent
+    path: "{{ playbook_dir }}/output/{{ item }}/ConfigMap_{{ item }}_kube-root-ca.crt.yaml"

--- a/crane-import-edit-tokens-loop.yml
+++ b/crane-import-edit-tokens-loop.yml
@@ -1,0 +1,16 @@
+- name: read yaml
+  set_fact:
+    token_yaml: "{{ lookup('file', token.path) | from_yaml }}"
+
+- name: Get the updated service account uid
+  shell: |
+         oc get sa -n {{ namespace }} {{ token_yaml.metadata.annotations['kubernetes.io/service-account.name'] }} -o go-template='{% raw %}{{ .metadata.uid }}{% endraw %}'
+  environment:
+    KUBECONFIG: "{{ dst_kubeconfig }}"
+  register: uid
+
+- name: replace uid
+  replace: 
+    path: "{{ token.path }}"
+    regexp: '^    kubernetes\.io/service-account\.uid:.*'
+    replace: "    kubernetes.io/service-account.uid: {{ uid.stdout }}"

--- a/crane-import-edit-tokens.yml
+++ b/crane-import-edit-tokens.yml
@@ -1,0 +1,15 @@
+- name: Find tokens
+  find:
+    path: "{{ playbook_dir }}/output/{{ item }}-tokens"
+    recurse: true
+    patterns: 'Secret.*token.*yaml'
+    use_regex: true
+  register: tokens
+
+- name: Edit Tokens
+  include_tasks: crane-import-edit-tokens-loop.yml
+  with_items: "{{ tokens.files }}"  
+  loop_control:
+    loop_var: token
+  vars:
+    namespace: "{{ item }}"   

--- a/crane-import-move-tokens.yml
+++ b/crane-import-move-tokens.yml
@@ -1,0 +1,18 @@
+- name: Find tokens
+  find:
+    path: "{{ playbook_dir }}/output/{{ item }}"
+    recurse: true
+    patterns: 'Secret.*token.*yaml'
+    use_regex: true
+  register: tokens
+
+- name: Ensure token dir exists
+  file:
+    state: directory
+    path: "{{ playbook_dir }}/output/{{ item }}-tokens"
+
+- name: Move tokens
+  shell: mv "{{ token.path }}" "{{ playbook_dir }}/output/{{ item }}-tokens"
+  with_items: "{{ tokens.files }}"
+  loop_control:
+    loop_var: "token"

--- a/crane-import-playbook.yml
+++ b/crane-import-playbook.yml
@@ -5,6 +5,22 @@
   vars:
     durations: "{{ item }}"
   tasks:
+  - name: Move tokens
+    include_tasks: crane-import-move-tokens.yml
+    with_items: "{{ namespaces }}"
+
+  - name: Delete kube-root-ca.crt configmap
+    include_tasks: crane-import-delete-kube-root-ca.yml
+    with_items: "{{ namespaces }}"
+
   - name: Run batched import
     include_tasks: crane-import-batch.yml
+    loop: "{{ namespaces | batch(batch_count) | list }}"
+
+  - name: Edit tokens
+    include_tasks: crane-import-edit-tokens.yml
+    with_items: "{{ namespaces }}"
+
+  - name: Create tokens
+    include_tasks: crane-import-tokens.yml
     loop: "{{ namespaces | batch(batch_count) | list }}"

--- a/crane-import-tokens.yml
+++ b/crane-import-tokens.yml
@@ -1,6 +1,6 @@
-- name: import namespace
+- name: import tokens
   shell: |
-         oc create -f {{ crane_path }}/output/{{ async_item }}
+         oc create -f {{ crane_path }}/output/{{ async_item }}-tokens
   environment:
     KUBECONFIG: "{{ dst_kubeconfig }}"
   async: 360


### PR DESCRIPTION
Instead of labeling and ignoring tokens completely, based on new undestanding I:
- move tokens out of the way
- import everything else
- look up the new uid for the SAs
- edit the tokens
- import tokens

There is also a task in there to delete the kube-root-ca.crt configmap if it exists. This is a 4 -> 4 issue, and not really relevant to the ISV migration, but it's making my day easier testing.

This should be adaptable to some extent or another based on input we get about imagestreams and imagestreamtags.